### PR TITLE
Remove unused variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Remove committed `.pyc` files and add `*.pyc` to `.gitignore`.
 - Typos in `README.md`.
 
+### Removed
+
+- Unused `VERSION` variable in `fabistrano.deploy`.
+
 
 ## 0.3 - 2013-04-29
 

--- a/fabistrano/deploy.py
+++ b/fabistrano/deploy.py
@@ -2,8 +2,6 @@ from fabric.api import env, sudo, run, put, task
 from fabistrano.helpers import with_defaults
 
 
-VERSION = "0.2"
-
 env.timeout = 6000
 
 def sudo_run(*args, **kwargs):


### PR DESCRIPTION
There is already a `__version__` variable elsewhere that is being used, and is up to date.